### PR TITLE
Improve search placeholder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,7 +225,7 @@ export default function App() {
           <div className="panel panel-left-top">
             <label>Search</label>
             <input
-              placeholder="hash mismatch"
+              placeholder={mode === "name" ? "e.g. curl" : "e.g. hash mismatch (3 characters minimum)"}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               maxLength={64}


### PR DESCRIPTION
"hash mismatch" doesn't make much sense when searching for a package name.

This tripped me up when I first used the app. :)