### PR TITLE
Track last successful builds for attrs

### DIFF
--- a/app/classify.py
+++ b/app/classify.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 import os
 import re
 import urllib.request
@@ -7,7 +8,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 from .config import RUNTIME_DIR, BUILD_LOGS_DIR
-from .db import get_db, reset_db
+from .db import get_db, init_db
 from .models import Build
 from .tagging import TAG_CHECKS, ErrorCheck
 
@@ -16,10 +17,6 @@ CSV_URL = (
     "Sigmanificient/nixpkgs-failure-notify"
     "/refs/heads/results"
     "/results/3-failures-x86_64-linux.csv"
-)
-
-GENERIC_ERROR_RE = re.compile(
-    r"(error:|Error:|ERROR|FAILED|fatal:|Failed)", re.IGNORECASE
 )
 
 
@@ -69,10 +66,6 @@ def get_status(log: str) -> str:
     return "failed"
 
 
-def is_hash_mismatch(log: str) -> bool:
-    return "error: hash mismatch in fixed-output derivation" in log
-
-
 def run_tag_check(rev_log: str, check: ErrorCheck) -> int | None:
     matched = re.search(check.pattern, rev_log)
 
@@ -88,7 +81,7 @@ def run_tag_check(rev_log: str, check: ErrorCheck) -> int | None:
 
 def find_error_and_tag(log: str) -> tuple[str, int | None]:
     lines = log.splitlines()
-    reversed_log = '\n'.join(lines[::-1])
+    reversed_log = "\n".join(lines[::-1])
 
     for check in TAG_CHECKS:
         line_num = run_tag_check(reversed_log, check)
@@ -99,53 +92,94 @@ def find_error_and_tag(log: str) -> tuple[str, int | None]:
 
 
 def main():
-    builds = []
     logs = sorted(
         BUILD_LOGS_DIR / entry
         for entry in os.listdir(BUILD_LOGS_DIR)
         if entry.endswith(".log")
     )
 
-    reset_db()
+    commit = json.loads((RUNTIME_DIR / "last-commit.json").read_text())
+    commit_rev = commit["rev"]
+    commit_date = commit["date"]
+
+    init_db()
     hydra_ids = fetch_hydra_ids()
     count = 0
-
     per_tags = defaultdict(list)
+    seen_attrpaths = set()
 
     with contextmanager(get_db)() as session:
+        existing: dict[str, Build] = {
+            b.attrpath: b for b in session.query(Build).all()
+        }
+
         for logfile in logs:
             attrpath = logfile.name.removesuffix(".log")
             print("processing", attrpath)
 
             log = logfile.read_bytes().decode(errors="ignore")
-            if get_status(log) != "failed":
+            status = get_status(log)
+            seen_attrpaths.add(attrpath)
+
+            if status == "success":
+                if attrpath in existing:
+                    b = existing[attrpath]
+                    b.tag = "success"
+                    b.hydra_id = hydra_ids.get(attrpath)
+                    b.error_line_number = None
+                    b.last_success_rev = commit_rev
+                    b.last_success_date = commit_date
+                else:
+                    session.add(
+                        Build(
+                            attrpath=attrpath,
+                            hydra_id=hydra_ids.get(attrpath),
+                            tag="success",
+                            error_line_number=None,
+                            last_success_rev=commit_rev,
+                            last_success_date=commit_date,
+                        )
+                    )
+                continue
+
+            if status != "failed":
                 continue
 
             if (
                 any(text in log for text in SKIP_BUILD_LOG_IF_MATCHES)
-                or log == "@@@ [FAIL] @@@\n" # empty log
+                or log == "@@@ [FAIL] @@@\n"
             ):
                 continue
 
-            matches = re.findall("error: attribute '.*' missing\n", log)
-            if matches:
+            if re.search("error: attribute '.*' missing\n", log):
                 continue
 
             tag, error_line = find_error_and_tag(log)
 
-            build = Build(
-                attrpath=attrpath,
-                hydra_id=hydra_ids.get(attrpath),
-                tag=tag,
-                error_line_number=error_line,
-            )
+            if attrpath in existing:
+                b = existing[attrpath]
+                b.tag = tag
+                b.hydra_id = hydra_ids.get(attrpath)
+                b.error_line_number = error_line
+            else:
+                b = Build(
+                    attrpath=attrpath,
+                    hydra_id=hydra_ids.get(attrpath),
+                    tag=tag,
+                    error_line_number=error_line,
+                    last_success_rev=None,
+                    last_success_date=None,
+                )
+                session.add(b)
 
-            per_tags[build.tag].append(build)
-            builds.append(build)
+            per_tags[tag].append(attrpath)
             count += 1
 
+        for attrpath, b in existing.items():
+            if attrpath not in seen_attrpaths:
+                session.delete(b)
+
         print("Registered", count, "packages")
-        session.add_all(builds)
         session.commit()
 
         print("\nTagged:")

--- a/app/db.py
+++ b/app/db.py
@@ -19,6 +19,5 @@ def get_db():
         db.close()
 
 
-def reset_db():
-    Base.metadata.drop_all(bind=engine)
+def init_db():
     Base.metadata.create_all(bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,9 @@ async def lifespan(_: FastAPI):
                 Build.hydra_id,
                 Build.tag,
                 Build.error_line_number,
-            )
+                Build.last_success_rev,
+                Build.last_success_date,
+            ).where(Build.tag != "success")
         ).all()
 
     state["builds"] = []
@@ -47,6 +49,8 @@ async def lifespan(_: FastAPI):
                 "hydra_id": b.hydra_id,
                 "tag": b.tag,
                 "error_line_number": b.error_line_number,
+                "last_success_rev": b.last_success_rev,
+                "last_success_date": b.last_success_date,
             }
         )
 

--- a/app/models.py
+++ b/app/models.py
@@ -6,8 +6,9 @@ Base = declarative_base()
 class Build(Base):
     __tablename__ = "builds"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    attrpath: Mapped[str]
+    attrpath: Mapped[str] = mapped_column(primary_key=True)
     hydra_id: Mapped[int | None]
     tag: Mapped[str]
     error_line_number: Mapped[int | None]
+    last_success_rev: Mapped[str | None]
+    last_success_date: Mapped[str | None]

--- a/src/App.scss
+++ b/src/App.scss
@@ -327,6 +327,16 @@ a {
   gap: 1em;
 }
 
+.log-meta-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1em;
+
+  p {
+    margin-left: auto;
+  }
+}
+
 .log-actions {
   display: flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,12 @@ import { useSearchParams } from "react-router-dom";
 import "./App.scss";
 
 interface Build {
-  id: number;
   attrpath: string;
   hydra_id: number | null;
   tag: string;
   error_line_number: number | null;
+  last_success_rev: string | null;
+  last_success_date: string | null;
 }
 
 interface Commit {
@@ -329,7 +330,14 @@ export default function App() {
 
         <div className="panel panel-right">
           <div className="log-meta">
-            <h2>Log Viewer</h2>
+            <div className="log-meta-header">
+              <h2>Log Viewer</h2>
+              { selectedBuild && (
+                selectedBuild.last_success_date
+                  ? <p>Last succeeded: {prettifyDate(selectedBuild.last_success_date)} (<a href={`https://github.com/NixOS/nixpkgs/commit/${selectedBuild.last_success_rev}`}>{selectedBuild.last_success_rev!.slice(0, 7)}</a>)</p>
+                  : <p>No successful build recorded</p>
+              )}
+            </div>
             {selectedBuild ? (
             <>
                 <p>


### PR DESCRIPTION
One use-case this dashboard could be adapted for is for getting a last working nixpkgs hash of a broken package. Say I want to update but a package is functionally stopping that update, I could use this tool to first verify the package is actually broken, and then get the nixpkgs commit hash i can carry through my flake to use for that package while its fix gets merged upstream. 

This PR proposes simply creating records for every build attempt, regardless of pass, and using the attribute itself over a gened primary key to make updates a little simpler. I dont see any reason to use a UID here since attributes of the packages are unique anyway. 

Here is an example of what this produces: 
<img width="649" height="65" alt="image" src="https://github.com/user-attachments/assets/a8e2ac2b-97f2-457c-9329-6657ad261ffa" />
