### PR TITLE
remove `cudaSupport`

### DIFF
--- a/build-all-packages.sh
+++ b/build-all-packages.sh
@@ -30,7 +30,6 @@ if [ ! -f ".run" ]; then
         config = {
           allowAliases = false;
           allowUnfree = true;
-          cudaSupport = true;
           recursionMode = \"hydra\";
         };
       };


### PR DESCRIPTION
Enabling `cudaSupport` breaks some stuff in nixpkgs, is not tested in ci for any failures, creates new broken packages, shadows failures that happen without it enabled.

So removed it so that we are more consistent with what hydra does.