### PR TITLE
Disable lineno selection in logs viewer

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -346,6 +346,7 @@ a {
     text-align: right;
     white-space: nowrap;
     opacity: .7;
+    user-select: none;
   }
 
   &.error::before {


### PR DESCRIPTION
By disabling lineno selection, you can just select and copy the logs without having to worry about copying the lines number with it.

## Before

<img width="1267" height="795" alt="image" src="https://github.com/user-attachments/assets/580eed66-cebd-400f-813f-a57ebed0300b" />


## After

<img width="1272" height="819" alt="image" src="https://github.com/user-attachments/assets/805d510b-ac83-4310-8a36-d1ffe5d99a10" />
