### PR TITLE
classify: ignore itchio games

### DIFF
--- a/app/classify.py
+++ b/app/classify.py
@@ -39,6 +39,7 @@ SKIP_BUILD_LOG_IF_MATCHES = (
     "nix-store --add-fixed",
     "nix-prefetch-url",
     "config.cplex.releasePath = /path/to/download",
+    "set the environment variable NIX_ITCHIO_API_KEY",
     # licenses based derivation
     "Microsoft Software License Terms are not accepted",
     "commercial license of Silverfort",


### PR DESCRIPTION
Games pulled from itch.io from the `fetchItchIo` helper require either external `NIX_ITCHIO_API_KEY` or manually downloading the assets.

Documentation:
https://github.com/nixos/nixpkgs/blob/c6a76137b96a25c8823f4ad6a88fda1b83b6d94e/doc/build-helpers/fetchers.chapter.md?plain=1#L1017

Relevant logs:
- https://nfd.1l.is/?selected=koboredux
- https://nfd.1l.is/?selected=ddm

```
...
Error: Either set the environment variable NIX_ITCHIO_API_KEY (for the nix-daemon in multi user mode) or manually download DungeonDuelMonsters-linux-x64.zip from https://mikaygo.itch.io/ddm and add it to the nix store.
```