### PR TITLE
handle nested attrsets

### DIFF
--- a/collect-packages.nix
+++ b/collect-packages.nix
@@ -5,7 +5,7 @@
     if lib.isDerivation pkg
     then ["${prefix}${name}"]
     else if pkg.recurseForDerivations or false || pkg.recurseForRelease or false
-    then packagesWith "${name}." pkg
+    then packagesWith "${prefix}${name}." pkg
     else [];
 
   packagesWith = prefix: set:


### PR DESCRIPTION
Noticed that the dashboard included some packages which don't even exist, looks like these were nested in some other attrs.